### PR TITLE
readme: emacs config link fix

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,7 +7,7 @@ I hope you like fiddling with your =.emacs.d= ad nauseam, 'cause I obviously do.
 I'm currently running [[https://www.debian.org/][Debian]] on a desktop with a single monitor. I use the [[https://i3wm.org/][i3
 window manager]], [[https://www.mozilla.org/en-US/firefox/][Firefox]], and [[https://www.gnu.org/software/emacs/][Emacs]].
 
-You're probably here for my literate [[./emacs/.emacs.d/configuration.org][Emacs config]]! Most of my time is spent in
+You're probably here for my literate [[./emacs/.config/emacs/configuration.org][Emacs config]]! Most of my time is spent in
 either Emacs or Firefox. I think a text editor is just a terrific environment
 for editing text, so I use Emacs for all kinds of things that "normal" people
 use specialized tools for, including:


### PR DESCRIPTION
The link in README is broken. Updated it.

P.S. Also the one on https://harryrschwartz.com/2016/02/15/switching-to-a-literate-emacs-configuration.html is broken as well ("[pretty nice results](https://github.com/hrs/dotfiles/blob/main/emacs/dot-emacs.d/configuration.org)") 